### PR TITLE
[INC-5312] use placeholder image when item image not set 

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}


### PR DESCRIPTION
# Description
addresses issue #1

use or operation to default to placeholder.png as item image source
![image](https://user-images.githubusercontent.com/121882828/210894931-07236106-392e-445f-8c71-7165931d8cf9.png)
